### PR TITLE
Make DenseAV discoverable on Hugging Face, add download stats

### DIFF
--- a/denseav/train.py
+++ b/denseav/train.py
@@ -134,7 +134,7 @@ class SpatialDropout(torch.nn.Module):
             return x
 
 
-class LitAVAligner(PyTorchModelHubMixin, pl.LightningModule):
+class LitAVAligner(pl.LightningModule, PyTorchModelHubMixin):
     def __init__(self,
                  code_dim,
                  image_model_type,

--- a/denseav/train.py
+++ b/denseav/train.py
@@ -19,6 +19,8 @@ from pytorch_lightning.utilities import grad_norm
 from torch.optim.lr_scheduler import CosineAnnealingWarmRestarts, SequentialLR, LambdaLR
 from torchmetrics.functional.classification import binary_average_precision
 
+from huggingface_hub import PyTorchModelHubMixin
+
 from denseav.aggregators import get_aggregator
 from denseav.aligners import get_aligner, ProgressiveGrowing
 from denseav.constants import *
@@ -132,7 +134,7 @@ class SpatialDropout(torch.nn.Module):
             return x
 
 
-class LitAVAligner(pl.LightningModule):
+class LitAVAligner(pl.LightningModule, PyTorchModelHubMixin):
     def __init__(self,
                  code_dim,
                  image_model_type,

--- a/denseav/train.py
+++ b/denseav/train.py
@@ -134,7 +134,7 @@ class SpatialDropout(torch.nn.Module):
             return x
 
 
-class LitAVAligner(pl.LightningModule, PyTorchModelHubMixin, repo_url="https://github.com/mhamilton723/DenseAV", license="MIT", tags=["denseav"]):
+class LitAVAligner(pl.LightningModule, PyTorchModelHubMixin, repo_url="https://github.com/mhamilton723/DenseAV", license="mit", tags=["denseav"]):
     def __init__(self,
                  code_dim,
                  image_model_type,

--- a/denseav/train.py
+++ b/denseav/train.py
@@ -134,7 +134,7 @@ class SpatialDropout(torch.nn.Module):
             return x
 
 
-class LitAVAligner(pl.LightningModule, PyTorchModelHubMixin):
+class LitAVAligner(PyTorchModelHubMixin, pl.LightningModule):
     def __init__(self,
                  code_dim,
                  image_model_type,

--- a/denseav/train.py
+++ b/denseav/train.py
@@ -134,7 +134,7 @@ class SpatialDropout(torch.nn.Module):
             return x
 
 
-class LitAVAligner(pl.LightningModule, PyTorchModelHubMixin):
+class LitAVAligner(pl.LightningModule, PyTorchModelHubMixin, repo_url="https://github.com/mhamilton723/DenseAV", license="MIT", tags=["denseav"]):
     def __init__(self,
                  code_dim,
                  image_model_type,

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -69,7 +69,7 @@ if __name__ == "__main__":
                              height=480)
     video_output3 = gr.Video(label="Visual Features", height=480)
 
-    models = {o: LitAVAligner.from_pretrained(f"nielsr/DenseAV-{o}") for o in options}
+    models = {o: LitAVAligner.from_pretrained(f"mhamilton723/DenseAV-{o}") for o in options}
 
 
     def process_video(video, model_option):

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -11,6 +11,7 @@ from PIL import Image
 from featup.util import norm
 from torchaudio.functional import resample
 
+from denseav.train import LitAVAligner
 from denseav.plotting import plot_attention_video, plot_2head_attention_video, plot_feature_video
 from denseav.shared import norm, crop_to_divisor, blur_dim
 from os.path import join
@@ -56,7 +57,7 @@ if __name__ == "__main__":
             print(f"{filename} already exists. Skipping download.")
 
     csv.field_size_limit(100000000)
-    options = ['language', "sound_and_language", "sound"]
+    options = ['language', "sound-language", "sound"]
     load_size = 224
     plot_size = 224
 
@@ -68,7 +69,7 @@ if __name__ == "__main__":
                              height=480)
     video_output3 = gr.Video(label="Visual Features", height=480)
 
-    models = {o: torch.hub.load("mhamilton723/DenseAV", o) for o in options}
+    models = {o: LitAVAligner.from_pretrained(f"nielsr/DenseAV-{o}") for o in options}
 
 
     def process_video(video, model_option):


### PR DESCRIPTION
Hi @mhamilton723,

Thanks for this nice work! I wrote a quick PoC to showcase that you can easily have integration with the 🤗 hub so that you can automatically load the various DenseAV models using `from_pretrained` (and push them using `push_to_hub`), track download numbers for your models (similar to models in the Transformers library), and have nice model cards on a per-model basis (with appropriate tags). It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Usage is as follows:

```
from denseav.train import LitAVAligner

model = LitAVAligner.from_pretrained("nielsr/DenseAV-sound-language")

# optionally, one can push a trained model to the hub
model.push_to_hub("nielsr/DenseAV")
```

This leverages `safetensors` for serialization of the weights rather than pickle. The corresponding model is here for now: https://huggingface.co/nielsr/DenseAV-sound-language. We could move all checkpoints to separate repos to an organization on the hub or your personal user account if you're interested.

Here's a Colab notebook: https://colab.research.google.com/drive/1HLfW7k-sCrRgtQCjlL3Uj8tBJpxjIXa1?usp=sharing

Would you be interested in this integration?

Kind regards,

Niels